### PR TITLE
Mejoras en el Query Parser

### DIFF
--- a/src/services/query-parser.service.ts
+++ b/src/services/query-parser.service.ts
@@ -14,7 +14,7 @@ class QueryParserService {
 
   private getFiltersArray(query: UrlQuery) {
     return Object.entries(query).reduce((filterQuery, [key, value]) => {
-      if (key.startsWith('_')) {
+      if (key.startsWith('_') && !key.startsWith('_id')) {
         return filterQuery;
       }
       return [...filterQuery, this.getFilterQuery(key, value as string)];


### PR DESCRIPTION
Se han incorporado las siguientes updates:
 - Parámetro _nin ya que no estaba en el API Template
 - Se arreglan fallos al leer _id por queryParam. Ahora no lo interpreta mal
 - Se arreglar problema con el _in y arrays